### PR TITLE
Async support for frame processor

### DIFF
--- a/HAProxy.StreamProcessingOffload.Agent/HAProxy.StreamProcessingOffload.Agent.csproj
+++ b/HAProxy.StreamProcessingOffload.Agent/HAProxy.StreamProcessingOffload.Agent.csproj
@@ -14,4 +14,8 @@
     <RepositoryUrl>https://github.com/haproxytech/haproxy-spoa-dotnet</RepositoryUrl>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
 </Project>

--- a/HAProxy.StreamProcessingOffload.Agent/IFrameProcessor.cs
+++ b/HAProxy.StreamProcessingOffload.Agent/IFrameProcessor.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using HAProxy.StreamProcessingOffload.Agent.Frames;
 
 namespace HAProxy.StreamProcessingOffload.Agent
@@ -36,6 +37,13 @@ namespace HAProxy.StreamProcessingOffload.Agent
         /// <param name="stream">The stream to receive and send frames on</param>
         /// <param name="notifyHandler">Function to invoke when a NOTIFY frame is received</param>
         void HandleStream(Stream stream, Func<NotifyFrame, IList<SpoeAction>> notifyHandler);
+
+        /// <summary>
+        /// Handles receiving and sending frames on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream to receive and send frames on</param>
+        /// <param name="notifyHandler">Function to invoke when a NOTIFY frame is received</param>
+        ValueTask HandleStreamAsync(Stream stream, Func<NotifyFrame, ValueTask<IList<SpoeAction>>> notifyHandler);
 
         /// <summary>
         /// Cancels processing on the given stream.

--- a/HAProxy.StreamProcessingOffload.Agent/IFrameProcessor.cs
+++ b/HAProxy.StreamProcessingOffload.Agent/IFrameProcessor.cs
@@ -50,5 +50,11 @@ namespace HAProxy.StreamProcessingOffload.Agent
         /// </summary>
         /// <param name="stream">The stream to cancel</param>
         void CancelStream(Stream stream);
+
+        /// <summary>
+        /// Cancels processing on the given stream.
+        /// </summary>
+        /// <param name="stream">The stream to cancel</param>
+        ValueTask CancelStreamAsync(Stream stream);
     }
 }


### PR DESCRIPTION
As discussed in #9, this PR adds async support to `IFrameProcessor` and its implementation `FrameProcessor`.

The API has been extended by two methods, which, as discussed in #9, take/return a `ValueTask` and `ValueTask<T>`.

```csharp
/// <summary>
/// Handles receiving and sending frames on the given stream.
/// </summary>
/// <param name="stream">The stream to receive and send frames on</param>
/// <param name="notifyHandler">Function to invoke when a NOTIFY frame is received</param>
ValueTask HandleStreamAsync(Stream stream, Func<NotifyFrame, ValueTask<IList<SpoeAction>>> notifyHandler);

/// <summary>
/// Cancels processing on the given stream.
/// </summary>
/// <param name="stream">The stream to cancel</param>
ValueTask CancelStreamAsync(Stream stream);
```

To avoid code duplication, I've used a pattern which uses a flag argument for internal methods to determine if the methods should be called asynchronously or not.
More information on that pattern:
- https://docs.microsoft.com/en-us/archive/msdn-magazine/2015/july/async-programming-brownfield-async-development#the-flag-argument-hack
- https://www.thereformedprogrammer.net/using-valuetask-to-create-methods-that-can-work-as-sync-or-async/

Having async methods also allows reading/writing the stream in an async manner, which further improves the performance, which is why I've included it in this PR.

For now, I've decided to not include `CancellationToken` overloads or default parameters for the async methods as this complicates things a lot, especially with the `notifyHandler` callback. In addition, we'd need to define when and how we'd safely cancel reading/writing from/to the stream.

As discussed in #9, using `ValueTask` and `ValueTask<T>` in `netstandard2.0` requires adding a dependency to `System.Threading.Tasks.Extensions`. As I think the multi-targeting out of scope for this PR, I've not implemented anything regarding this topic.